### PR TITLE
Add escape as window close shortcut instead of cancel button

### DIFF
--- a/src/org/vaadin/dialogs/DefaultConfirmDialogFactory.java
+++ b/src/org/vaadin/dialogs/DefaultConfirmDialogFactory.java
@@ -53,6 +53,7 @@ public class DefaultConfirmDialogFactory implements Factory {
         final boolean threeWay = notOkCaption != null;
         // Create a confirm dialog
         final ConfirmDialog confirm = new ConfirmDialog();
+        confirm.setCloseShortcut(KeyCode.ESCAPE);
         confirm.setId(ConfirmDialog.DIALOG_ID);
         confirm.setCaption(caption != null ? caption : DEFAULT_CAPTION);
 
@@ -107,7 +108,6 @@ public class DefaultConfirmDialogFactory implements Factory {
                 : DEFAULT_CANCEL_CAPTION);
         cancel.setData(null);
         cancel.setId(ConfirmDialog.CANCEL_ID);
-        cancel.setClickShortcut(KeyCode.ESCAPE, null);
         buttons.addComponent(cancel);
         confirm.setCancelButton(cancel);
 
@@ -124,7 +124,7 @@ public class DefaultConfirmDialogFactory implements Factory {
                 : DEFAULT_OK_CAPTION);
         ok.setData(true);
         ok.setId(ConfirmDialog.OK_ID);
-        ok.setClickShortcut(KeyCode.ENTER, null);
+        ok.setClickShortcut(KeyCode.ENTER);
         ok.setStyleName(Reindeer.BUTTON_DEFAULT);
         ok.focus();
         buttons.addComponent(ok);

--- a/test/org/vaadin/dialogs/TestConfirmDialog.java
+++ b/test/org/vaadin/dialogs/TestConfirmDialog.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
@@ -116,6 +117,24 @@ public class TestConfirmDialog extends TestBenchTestCase {
 
     }
 
+    /** Opens dialog and presses enter key. */
+    @Test
+    public void testEnterKey() {
+
+        // Open confirm dialog
+        clickButton(ConfirmDialogTestUI.OPEN_BUTTON_1);
+
+        // Get the dialog
+        WindowElement dialog = findConfirmDialog();
+
+        // Press enter key
+        dialog.getWrappedElement().findElement(By.className("v-scrollable")).sendKeys(Keys.ENTER);
+
+        // Assert notification value
+        assertTrue(findNotification().getText().contains("true"));
+
+    }
+
     /** Opens dialog and presses cancel. */
     @Test
     public void testCancel() {
@@ -133,7 +152,25 @@ public class TestConfirmDialog extends TestBenchTestCase {
         assertTrue(findNotification().getText().contains("false"));
 
     }
-    
+
+    /** Opens dialog and presses escape key. */
+    @Test
+    public void testEscapeKey() {
+
+        // Open confirm dialog
+        clickButton(ConfirmDialogTestUI.OPEN_BUTTON_1);
+
+        // Get the dialog
+        WindowElement dialog = findConfirmDialog();
+
+        // Press escape key
+        dialog.getWrappedElement().findElement(By.className("v-scrollable")).sendKeys(Keys.ESCAPE);
+
+        // Assert notification value
+        assertTrue(findNotification().getText().contains("false"));
+
+    }
+
     /** Opens dialog and presses cancel. */
     @Test
     public void testThreeWayOK() {


### PR DESCRIPTION
Escape key acts as window close shortcut already be default, which resulted in both window closed and button clicked (which is processed after window is already closed), which in turn gives a lot of nasty warnings in the log:
```
WARNING: Ignoring action for disabled connector com.vaadin.ui.Button, caption=Ok
```

This patch fixes the problem without changing behaviour.