### PR TITLE
Fix: long messages won't wrap to new line

### DIFF
--- a/src/org/vaadin/dialogs/DefaultConfirmDialogFactory.java
+++ b/src/org/vaadin/dialogs/DefaultConfirmDialogFactory.java
@@ -94,6 +94,7 @@ public class DefaultConfirmDialogFactory implements Factory {
 
         // Always HTML, but escape
         Label text = new Label("", com.vaadin.shared.ui.ContentMode.HTML);
+        text.setWidth(100, com.vaadin.server.Sizeable.Unit.PERCENTAGE);
         text.setId(ConfirmDialog.MESSAGE_ID);
         scrollContent.addComponent(text);
         confirm.setMessageLabel(text);


### PR DESCRIPTION
Long messages won't wrap to new line because of the css class .v-label-undef-w which has white-space: nowrap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/samie/vaadin-confirmdialog/34)
<!-- Reviewable:end -->
